### PR TITLE
Apple-inspired liquid glass theme — mobile-first redesign

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#fafaf9" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#0c0a09" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f5f5f7" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/components/layout/AmbientBackground.tsx
+++ b/src/components/layout/AmbientBackground.tsx
@@ -1,0 +1,10 @@
+// src/components/layout/AmbientBackground.tsx — Ambient mesh orbs for liquid glass depth
+export function AmbientBackground() {
+  return (
+    <div className="ambient-bg" aria-hidden="true">
+      <div className="ambient-orb ambient-orb-blue -top-24 -right-16 h-72 w-72 opacity-80 md:h-96 md:w-96" />
+      <div className="ambient-orb ambient-orb-violet top-1/3 -left-24 h-64 w-64 opacity-70 md:h-80 md:w-80" />
+      <div className="ambient-orb ambient-orb-teal bottom-1/4 right-1/4 h-56 w-56 opacity-60 md:h-72 md:w-72" />
+    </div>
+  )
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,4 +1,4 @@
-// src/components/layout/Footer.tsx — Site footer
+// src/components/layout/Footer.tsx — Glass footer with grouped navigation
 import { Link } from 'react-router-dom'
 import { footerNavGroups } from '@/data/navigation'
 import { siteConfig } from '@/data/site'
@@ -7,12 +7,12 @@ export function Footer() {
   const year = new Date().getFullYear()
 
   return (
-    <footer className="border-t border-border py-16">
-      <div className="mx-auto max-w-6xl px-6">
-        <div className="flex flex-col gap-12 md:flex-row md:justify-between">
+    <footer className="px-3 pb-[max(1rem,env(safe-area-inset-bottom))] pt-6 sm:px-4">
+      <div className="mx-auto max-w-6xl liquid-glass rounded-[1.5rem] p-6 sm:rounded-[1.75rem] sm:p-8">
+        <div className="flex flex-col gap-10 md:flex-row md:justify-between">
           <div className="max-w-sm">
             <p className="text-lg font-semibold tracking-tight">{siteConfig.founder.name}</p>
-            <p className="mt-2 text-sm text-muted leading-relaxed">
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
               {siteConfig.founder.tagline}
             </p>
           </div>
@@ -23,7 +23,7 @@ export function Footer() {
           >
             {footerNavGroups.map((group) => (
               <div key={group.title}>
-                <p className="text-xs font-medium tracking-wide text-muted uppercase">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                   {group.title}
                 </p>
                 <ul className="mt-3 space-y-2">
@@ -34,14 +34,14 @@ export function Footer() {
                           href={link.href}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-sm text-muted transition-colors hover:text-foreground"
+                          className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                         >
                           {link.label}
                         </a>
                       ) : (
                         <Link
                           to={link.href}
-                          className="text-sm text-muted transition-colors hover:text-foreground"
+                          className="text-sm text-muted-foreground transition-colors hover:text-foreground"
                         >
                           {link.label}
                         </Link>
@@ -54,7 +54,7 @@ export function Footer() {
           </nav>
         </div>
 
-        <div className="mt-12 flex flex-col gap-2 border-t border-border pt-8 sm:flex-row sm:items-center sm:justify-between">
+        <div className="mt-10 flex flex-col gap-2 border-t border-foreground/8 pt-6 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs text-muted-foreground">
             © {year} {siteConfig.founder.name}. All rights reserved.
           </p>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,101 +1,106 @@
-// src/components/layout/Header.tsx — Site header with navigation
+// src/components/layout/Header.tsx
+// Apple-style floating glass navigation — mobile sheet + desktop bar.
+
 import { useState } from 'react'
-import { Link, useLocation } from 'react-router-dom'
+import { Link, NavLink } from 'react-router-dom'
+import { AnimatePresence, motion } from 'framer-motion'
 import { Menu, X } from 'lucide-react'
-import { primaryNav } from '@/data/navigation'
-import { siteConfig } from '@/data/site'
-import { ThemeToggle } from '@/components/ui/theme-toggle'
-import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { siteConfig } from '@/data/site'
+import { primaryNav } from '@/data/navigation'
+import type { NavItem } from '@/data/navigation'
+import { Button } from '@/components/ui/button'
 
 export function Header() {
   const [open, setOpen] = useState(false)
-  const location = useLocation()
+  const navItems = primaryNav.filter((item) => item.href !== '/contact')
 
   return (
-    <header className="fixed top-0 right-0 left-0 z-50">
-      <div className="mx-auto max-w-6xl px-6">
-        <nav
-          className="mt-4 flex items-center justify-between rounded-2xl border border-border glass px-4 py-3 shadow-premium"
-          aria-label="Main navigation"
-        >
-          <Link
-            to="/"
-            className="text-sm font-semibold tracking-tight transition-opacity hover:opacity-70"
-            onClick={() => setOpen(false)}
-          >
-            {siteConfig.founder.name}
-          </Link>
+    <header className="fixed inset-x-0 top-0 z-50 px-3 pt-[max(0.5rem,env(safe-area-inset-top))] sm:px-4">
+      <div className="mx-auto flex h-12 max-w-6xl items-center justify-between gap-3 rounded-[1.25rem] border border-white/50 bg-white/55 px-3 shadow-[0_4px_24px_rgba(15,23,42,0.06)] backdrop-blur-2xl backdrop-saturate-150 sm:h-14 sm:px-4">
+        <Link to="/" className="flex min-w-0 items-center gap-2.5" onClick={() => setOpen(false)}>
+          <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-[#0071e3] to-[#5ac8fa] text-xs font-bold text-white shadow-sm">
+            JW
+          </span>
+          <span className="truncate text-sm font-semibold tracking-tight text-foreground">
+            {siteConfig.name}
+          </span>
+        </Link>
 
-          <div className="hidden items-center gap-1 md:flex">
-            {primaryNav.map((item) => (
-              <Link
-                key={item.href}
-                to={item.href}
-                className={cn(
-                  'rounded-full px-3 py-1.5 text-sm transition-colors',
-                  location.pathname === item.href
-                    ? 'bg-accent text-foreground font-medium'
-                    : 'text-muted hover:text-foreground',
-                )}
-              >
-                {item.label}
-              </Link>
-            ))}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <Button asChild size="sm" className="hidden sm:inline-flex">
-              <Link to="/contact">Contact</Link>
-            </Button>
-            <ThemeToggle className="hidden sm:flex" />
-            <button
-              type="button"
-              className="flex h-10 w-10 items-center justify-center rounded-full border border-border md:hidden"
-              onClick={() => setOpen(!open)}
-              aria-expanded={open}
-              aria-label={open ? 'Close menu' : 'Open menu'}
+        <nav className="hidden items-center gap-0.5 md:flex" aria-label="Main">
+          {navItems.map((item: NavItem) => (
+            <NavLink
+              key={item.href}
+              to={item.href}
+              className={({ isActive }) =>
+                cn(
+                  'rounded-full px-3 py-1.5 text-[13px] font-medium transition-colors',
+                  isActive
+                    ? 'bg-foreground/8 text-foreground'
+                    : 'text-muted-foreground hover:bg-foreground/5 hover:text-foreground',
+                )
+              }
             >
-              {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-            </button>
-          </div>
+              {item.label}
+            </NavLink>
+          ))}
         </nav>
 
+        <div className="hidden md:block">
+          <Button asChild size="sm" variant="primary">
+            <Link to="/contact">Contact</Link>
+          </Button>
+        </div>
+
+        <button
+          type="button"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-foreground transition-colors hover:bg-foreground/5 md:hidden"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-label={open ? 'Close menu' : 'Open menu'}
+        >
+          {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
+      </div>
+
+      <AnimatePresence>
         {open && (
-          <div className="mt-2 rounded-2xl border border-border glass p-4 shadow-elevated md:hidden">
-            <div className="flex flex-col gap-1">
-              {primaryNav.map((item) => (
-                <Link
+          <motion.div
+            initial={{ opacity: 0, y: -8, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.98 }}
+            transition={{ duration: 0.2, ease: [0.25, 0.1, 0.25, 1] }}
+            className="mx-auto mt-2 max-w-6xl overflow-hidden rounded-[1.25rem] border border-white/50 bg-white/70 p-2 shadow-[0_8px_32px_rgba(15,23,42,0.1)] backdrop-blur-2xl md:hidden"
+          >
+            <nav className="flex flex-col gap-0.5" aria-label="Mobile">
+              {navItems.map((item: NavItem) => (
+                <NavLink
                   key={item.href}
                   to={item.href}
-                  className={cn(
-                    'rounded-xl px-4 py-3 text-sm transition-colors',
-                    location.pathname === item.href
-                      ? 'bg-accent font-medium'
-                      : 'text-muted hover:bg-accent hover:text-foreground',
-                  )}
                   onClick={() => setOpen(false)}
+                  className={({ isActive }) =>
+                    cn(
+                      'rounded-xl px-4 py-3 text-[15px] font-medium transition-colors',
+                      isActive
+                        ? 'bg-[#0071e3]/10 text-[#0071e3]'
+                        : 'text-foreground hover:bg-foreground/5',
+                    )
+                  }
                 >
-                  <span className="block font-medium">{item.label}</span>
-                  {item.description && (
-                    <span className="text-xs text-muted">{item.description}</span>
-                  )}
-                </Link>
+                  {item.label}
+                </NavLink>
               ))}
               <Link
                 to="/contact"
-                className="mt-2 rounded-xl bg-primary px-4 py-3 text-center text-sm font-medium text-primary-foreground"
                 onClick={() => setOpen(false)}
+                className="mt-1 rounded-xl bg-[#0071e3] px-4 py-3 text-center text-[15px] font-semibold text-white"
               >
                 Contact
               </Link>
-            </div>
-            <div className="mt-4 flex justify-center">
-              <ThemeToggle />
-            </div>
-          </div>
+            </nav>
+          </motion.div>
         )}
-      </div>
+      </AnimatePresence>
     </header>
   )
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 // src/components/layout/Layout.tsx — Page layout wrapper
 import { Header } from './Header'
 import { Footer } from './Footer'
+import { AmbientBackground } from './AmbientBackground'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -8,7 +9,8 @@ interface LayoutProps {
 
 export function Layout({ children }: LayoutProps) {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="relative flex min-h-screen flex-col">
+      <AmbientBackground />
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground"
@@ -16,7 +18,7 @@ export function Layout({ children }: LayoutProps) {
         Skip to content
       </a>
       <Header />
-      <main id="main-content" className="flex-1 pt-24">
+      <main id="main-content" className="flex-1 pt-[3.75rem] sm:pt-16 md:pt-[4.5rem]">
         {children}
       </main>
       <Footer />

--- a/src/components/sections/ContactSection.tsx
+++ b/src/components/sections/ContactSection.tsx
@@ -1,4 +1,4 @@
-// src/components/sections/ContactSection.tsx — Contact section
+// src/components/sections/ContactSection.tsx — Contact channels in glass tiles
 import { Link } from 'react-router-dom'
 import { ArrowRight, Mail, ExternalLink } from 'lucide-react'
 import { contactConfig } from '@/data/contact'
@@ -12,28 +12,29 @@ export function ContactSection({ compact = false, hideHeader }: { compact?: bool
       eyebrow="Contact"
       title={contactConfig.title}
       description={contactConfig.description}
-      className={compact ? 'py-16 md:py-24' : undefined}
       hideHeader={hideHeader}
+      compact={compact}
+      glass
     >
-      <div className="flex flex-col gap-3 sm:grid sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         {contactConfig.channels.map((channel) => (
           <div
             key={channel.id}
-            className="rounded-xl border border-border/60 px-5 py-4 transition-colors hover:border-border sm:px-6 sm:py-5"
+            className="liquid-glass-card rounded-2xl px-4 py-4 sm:px-5 sm:py-5"
           >
-            <p className="text-xs font-medium text-muted uppercase tracking-wide">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {channel.label}
             </p>
             <a
               href={channel.href}
               target={channel.type === 'email' ? undefined : '_blank'}
               rel={channel.type === 'email' ? undefined : 'noopener noreferrer'}
-              className="mt-2 flex items-center gap-2 text-sm font-medium transition-opacity hover:opacity-70"
+              className="mt-2 flex items-center gap-2 text-sm font-semibold transition-opacity hover:opacity-80"
             >
               {channel.type === 'email' && <Mail className="h-4 w-4" aria-hidden="true" />}
-              {channel.value}
+              <span className="break-all">{channel.value}</span>
               {channel.type !== 'email' && (
-                <ExternalLink className="h-3 w-3 text-muted" aria-hidden="true" />
+                <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" aria-hidden="true" />
               )}
             </a>
           </div>
@@ -41,7 +42,7 @@ export function ContactSection({ compact = false, hideHeader }: { compact?: bool
       </div>
 
       {!compact && (
-        <div className="mt-12">
+        <div className="mt-8 sm:mt-10">
           <Button asChild>
             <Link to="/contact">
               Contact page

--- a/src/components/sections/EvidenceSection.tsx
+++ b/src/components/sections/EvidenceSection.tsx
@@ -1,4 +1,4 @@
-// src/components/sections/EvidenceSection.tsx — Verifiable evidence cards
+// src/components/sections/EvidenceSection.tsx — Verifiable evidence in glass cards
 import { Link } from 'react-router-dom'
 import {
   Apple,
@@ -21,6 +21,7 @@ import {
 } from '@/data/evidence'
 import { Section } from '@/components/ui/section'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 const iconMap: Record<EvidenceType, typeof Globe> = {
   'app-store': Apple,
@@ -47,10 +48,10 @@ function EvidenceCard({ item }: { item: EvidenceItem }) {
       className="block h-full"
       aria-label={`${item.title} (opens in new tab)`}
     >
-      <article className="group flex h-full flex-col rounded-xl border border-border/60 bg-card/50 p-6 transition-colors hover:border-border hover:bg-card">
-        <Icon className="h-5 w-5 text-muted" aria-hidden="true" />
-        <h3 className="mt-4 font-medium">{item.title}</h3>
-        <p className="mt-1.5 flex-1 text-sm text-muted leading-snug">{item.description}</p>
+      <article className="liquid-glass-card group flex h-full flex-col rounded-2xl p-5 transition-transform duration-200 hover:scale-[1.01] sm:p-6">
+        <Icon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+        <h3 className="mt-4 font-semibold tracking-tight">{item.title}</h3>
+        <p className="mt-1.5 flex-1 text-sm leading-snug text-muted-foreground">{item.description}</p>
         {item.value && (
           <p className="mt-3 text-2xl font-semibold tracking-tight tabular-nums">{item.value}</p>
         )}
@@ -61,10 +62,10 @@ function EvidenceCard({ item }: { item: EvidenceItem }) {
 
 function EvidenceMetricCard({ metric }: { metric: EvidenceProductMetric }) {
   return (
-    <article className="group flex h-full flex-col rounded-xl border border-border/60 bg-card/50 p-6 transition-colors hover:border-border hover:bg-card">
+    <article className="liquid-glass-card flex h-full flex-col rounded-2xl p-5 sm:p-6">
       <p className="text-2xl font-semibold tracking-tight tabular-nums">{metric.value}</p>
-      <h3 className="mt-4 font-medium">{metric.title}</h3>
-      <p className="mt-1.5 flex-1 text-sm text-muted leading-snug">{metric.source}</p>
+      <h3 className="mt-4 font-semibold tracking-tight">{metric.title}</h3>
+      <p className="mt-1.5 flex-1 text-sm leading-snug text-muted-foreground">{metric.source}</p>
     </article>
   )
 }
@@ -74,11 +75,13 @@ export function EvidenceSection({
   hideHeader,
   compact,
   showProductMetrics,
+  glass,
 }: {
   limit?: number
   hideHeader?: boolean
   compact?: boolean
   showProductMetrics?: boolean
+  glass?: boolean
 }) {
   const items = limit ? evidenceItems.slice(0, limit) : evidenceItems
 
@@ -89,6 +92,7 @@ export function EvidenceSection({
       description="Verifiable facts. No testimonials."
       hideHeader={hideHeader}
       compact={compact}
+      glass={glass ?? !hideHeader}
     >
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((item) => (
@@ -97,7 +101,7 @@ export function EvidenceSection({
       </div>
 
       {showProductMetrics && (
-        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        <div className={cn('grid gap-3 sm:grid-cols-2 lg:grid-cols-3', items.length > 0 && 'mt-3')}>
           {evidenceProductMetrics.map((metric) => (
             <EvidenceMetricCard key={metric.id} metric={metric} />
           ))}
@@ -105,7 +109,7 @@ export function EvidenceSection({
       )}
 
       {limit && evidenceItems.length > limit && (
-        <div className="mt-12">
+        <div className="mt-8 sm:mt-10">
           <Button asChild variant="secondary">
             <Link to="/evidence">
               All evidence

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,4 +1,4 @@
-// src/components/sections/Hero.tsx — Homepage hero section
+// src/components/sections/Hero.tsx — Homepage hero with mobile-first liquid glass flow
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { ArrowRight } from 'lucide-react'
@@ -27,69 +27,50 @@ export function Hero() {
   return (
     <section
       id="hero"
-      className="relative overflow-hidden pb-10 pt-8 md:pb-16 md:pt-16"
+      className="px-3 pb-6 pt-4 sm:px-4 md:pb-10 md:pt-8"
       aria-labelledby="hero-heading"
     >
-      <div className="pointer-events-none absolute inset-0 gradient-subtle" />
-      <div className="pointer-events-none absolute top-0 right-0 hidden h-[600px] w-[600px] -translate-y-1/4 translate-x-1/4 rounded-full bg-hero-glow blur-3xl md:block" />
+      <div className="mx-auto grid max-w-6xl items-center gap-8 lg:grid-cols-2 lg:gap-16">
+        <motion.div
+          className="liquid-glass rounded-[1.5rem] p-6 sm:rounded-[1.75rem] sm:p-8 lg:p-10"
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          <Eyebrow className="mb-3">{siteConfig.founder.eyebrow}</Eyebrow>
 
-      <div className="relative mx-auto max-w-6xl px-6">
-        <div className="grid items-center gap-10 lg:grid-cols-2 lg:gap-20">
-          <div>
-            <motion.div
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.5 }}
-            >
-              <Eyebrow className="mb-4">{siteConfig.founder.eyebrow}</Eyebrow>
-            </motion.div>
-
-            <motion.h1
-              id="hero-heading"
-              className="text-4xl font-semibold tracking-tight text-balance sm:text-5xl lg:text-7xl"
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.1 }}
-            >
-              <HeroHeadline />
-            </motion.h1>
-
-            <motion.p
-              className="mt-5 max-w-md text-base text-muted leading-relaxed text-balance md:mt-6"
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.2 }}
-            >
-              {siteConfig.founder.subheading}
-            </motion.p>
-
-            <motion.div
-              className="mt-8 flex flex-wrap gap-3 md:mt-10"
-              initial={{ opacity: 0, y: 16 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.3 }}
-            >
-              <Button asChild size="lg">
-                <Link to="/kids-call-home">
-                  Kids Call Home
-                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
-                </Link>
-              </Button>
-              <Button asChild variant="secondary" size="lg">
-                <Link to="/journey">Founder journey</Link>
-              </Button>
-            </motion.div>
-          </div>
-
-          <motion.div
-            className="hidden lg:block"
-            initial={{ opacity: 0, scale: 0.96 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ duration: 0.8, delay: 0.2 }}
+          <h1
+            id="hero-heading"
+            className="text-balance text-[2rem] font-semibold leading-[1.08] tracking-tight sm:text-5xl lg:text-[3.5rem]"
           >
-            <ProductMockup />
-          </motion.div>
-        </div>
+            <HeroHeadline />
+          </h1>
+
+          <p className="mt-4 max-w-md text-pretty text-base leading-relaxed text-muted-foreground sm:mt-5 sm:text-lg">
+            {siteConfig.founder.subheading}
+          </p>
+
+          <div className="mt-6 flex flex-col gap-2.5 sm:mt-8 sm:flex-row sm:flex-wrap sm:gap-3">
+            <Button asChild size="lg" className="w-full sm:w-auto">
+              <Link to="/kids-call-home">
+                Kids Call Home
+                <ArrowRight className="h-4 w-4" aria-hidden="true" />
+              </Link>
+            </Button>
+            <Button asChild variant="secondary" size="lg" className="w-full sm:w-auto">
+              <Link to="/journey">Founder journey</Link>
+            </Button>
+          </div>
+        </motion.div>
+
+        <motion.div
+          className="hidden lg:block"
+          initial={{ opacity: 0, scale: 0.97 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.7, delay: 0.15, ease: [0.25, 0.1, 0.25, 1] }}
+        >
+          <ProductMockup />
+        </motion.div>
       </div>
     </section>
   )

--- a/src/components/sections/JourneySection.tsx
+++ b/src/components/sections/JourneySection.tsx
@@ -1,4 +1,4 @@
-// src/components/sections/JourneySection.tsx — Founder journey timeline
+// src/components/sections/JourneySection.tsx — Founder journey timeline with glass rail
 import { Link } from 'react-router-dom'
 import { ArrowRight } from 'lucide-react'
 import { journeyMilestones } from '@/data/journey'
@@ -15,29 +15,34 @@ function TimelineItem({
   isLast: boolean
 }) {
   return (
-    <div className="relative flex gap-6 pb-8">
+    <div className="relative flex gap-4 pb-6 sm:gap-5 sm:pb-7">
       {!isLast && (
-        <div className="absolute top-3 left-[11px] h-full w-px bg-border" aria-hidden="true" />
+        <div
+          className="absolute top-3 left-[10px] h-full w-px bg-foreground/10"
+          aria-hidden="true"
+        />
       )}
       <div
         className={cn(
-          'relative z-10 mt-1 h-[22px] w-[22px] shrink-0 rounded-full border-2',
+          'relative z-10 mt-0.5 h-5 w-5 shrink-0 rounded-full border-2 sm:h-[22px] sm:w-[22px]',
           milestone.status === 'active' ? 'border-kch bg-kch' : 'border-foreground bg-foreground',
         )}
         aria-hidden="true"
       />
-      <div className="flex-1 pt-0">
+      <div className="liquid-glass-card min-w-0 flex-1 rounded-2xl p-4 sm:p-5">
         <div className="flex flex-wrap items-center gap-2">
-          <time className="text-sm font-medium text-muted tabular-nums">{milestone.date}</time>
+          <time className="text-sm font-medium tabular-nums text-muted-foreground">
+            {milestone.date}
+          </time>
           <Badge variant={milestone.status === 'active' ? 'active' : 'default'}>
             {milestone.type}
           </Badge>
         </div>
-        <h3 className="mt-1 text-base font-medium">{milestone.title}</h3>
+        <h3 className="mt-1.5 text-base font-semibold tracking-tight">{milestone.title}</h3>
         {milestone.company && (
-          <p className="text-sm text-muted">{milestone.company}</p>
+          <p className="text-sm text-muted-foreground">{milestone.company}</p>
         )}
-        <p className="mt-1 text-sm text-muted leading-snug">{milestone.description}</p>
+        <p className="mt-1.5 text-sm leading-snug text-muted-foreground">{milestone.description}</p>
       </div>
     </div>
   )
@@ -62,6 +67,7 @@ export function JourneySection({
       description="Companies founded. Products launched. Milestones reached."
       hideHeader={hideHeader}
       compact={compact}
+      glass
     >
       <div className="max-w-xl">
         {milestones.map((milestone, i) => (
@@ -74,7 +80,7 @@ export function JourneySection({
       </div>
 
       {limit && journeyMilestones.length > limit && (
-        <div className="mt-8">
+        <div className="mt-6 sm:mt-8">
           <Button asChild variant="secondary">
             <Link to="/journey">
               Full timeline

--- a/src/components/sections/KidsCallHomeSection.tsx
+++ b/src/components/sections/KidsCallHomeSection.tsx
@@ -1,4 +1,4 @@
-// src/components/sections/KidsCallHomeSection.tsx — Featured flagship product section
+// src/components/sections/KidsCallHomeSection.tsx — Flagship product with glass flow
 import { Link } from 'react-router-dom'
 import { ArrowRight, ExternalLink } from 'lucide-react'
 import { kidsCallHome } from '@/data/kids-call-home'
@@ -10,42 +10,42 @@ import { FlagshipPanel } from '@/components/visuals/FlagshipPanel'
 
 export function KidsCallHomeSection() {
   return (
-    <Section id="kids-call-home" className="gradient-subtle py-12 md:py-28" animate={false}>
-      <div className="flex flex-col gap-6 lg:gap-12">
-        <ProductMockup compact className="lg:hidden" />
+    <Section id="kids-call-home" compact glass animate={false}>
+      <div className="flex flex-col gap-6 lg:gap-10">
+        <ProductMockup compact className="mx-auto lg:hidden" />
 
-        <div className="grid items-start gap-6 lg:grid-cols-2 lg:gap-16">
-        <div className="flex flex-col gap-6 lg:gap-8">
-          <div>
-            <Eyebrow className="mb-3">Flagship product</Eyebrow>
-            <h2 className="text-4xl font-semibold tracking-tight text-balance md:text-6xl lg:text-7xl">
-              {kidsCallHome.name}
-            </h2>
-            <p className="mt-4 max-w-md text-base text-muted text-balance md:mt-6 md:text-lg">
-              {kidsCallHome.summary}
-            </p>
+        <div className="grid items-start gap-6 lg:grid-cols-2 lg:gap-12">
+          <div className="flex flex-col gap-5 sm:gap-6">
+            <div>
+              <Eyebrow className="mb-2.5">Flagship product</Eyebrow>
+              <h2 className="text-balance text-[1.75rem] font-semibold leading-[1.1] tracking-tight sm:text-4xl lg:text-5xl">
+                {kidsCallHome.name}
+              </h2>
+              <p className="mt-3 max-w-md text-pretty text-base leading-relaxed text-muted-foreground sm:mt-4">
+                {kidsCallHome.summary}
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2.5 sm:flex-row sm:flex-wrap">
+              <Button asChild size="lg" className="w-full sm:w-auto">
+                <a href={kidsCallHome.url} target="_blank" rel="noopener noreferrer">
+                  Visit site
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                </a>
+              </Button>
+              <Button asChild variant="secondary" size="lg" className="w-full sm:w-auto">
+                <Link to="/kids-call-home">
+                  Details
+                  <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                </Link>
+              </Button>
+            </div>
+
+            <FlagshipPanel />
           </div>
 
-          <div className="flex flex-wrap gap-2.5">
-            <Button asChild size="lg" className="h-11">
-              <a href={kidsCallHome.url} target="_blank" rel="noopener noreferrer">
-                Visit site
-                <ExternalLink className="h-4 w-4" aria-hidden="true" />
-              </a>
-            </Button>
-            <Button asChild variant="secondary" size="lg" className="h-11">
-              <Link to="/kids-call-home">
-                Details
-                <ArrowRight className="h-4 w-4" aria-hidden="true" />
-              </Link>
-            </Button>
-          </div>
-
-          <FlagshipPanel />
+          <ProductMockup className="mx-auto hidden lg:block" />
         </div>
-
-        <ProductMockup className="hidden lg:block" />
-      </div>
       </div>
     </Section>
   )

--- a/src/components/sections/MetricsBar.tsx
+++ b/src/components/sections/MetricsBar.tsx
@@ -82,7 +82,7 @@ function MetricItem({
         >
           {display}
         </p>
-        <h3 className="mt-0.5 text-[9px] font-medium leading-snug text-muted md:mt-1 md:text-xs">
+        <h3 className="mt-0.5 text-[9px] font-medium leading-snug text-muted-foreground md:mt-1 md:text-xs">
           {metric.title}
         </h3>
         {metric.description && <span className="sr-only">{metric.description}</span>}
@@ -92,7 +92,7 @@ function MetricItem({
 
   return (
     <motion.article
-      className="group relative rounded-xl border border-border/60 bg-card/50 px-5 py-4 transition-colors hover:border-border hover:bg-card"
+      className="group relative liquid-glass-card rounded-2xl px-5 py-4 transition-transform duration-200 hover:scale-[1.01]"
       title={metric.description}
       initial={reducedMotion ? false : { opacity: 0, y: 12 }}
       animate={active && !reducedMotion ? { opacity: 1, y: 0 } : {}}
@@ -108,7 +108,7 @@ function MetricItem({
           >
             {display}
           </p>
-          <h3 className="mt-1.5 text-xs font-medium text-muted leading-snug">{metric.title}</h3>
+          <h3 className="mt-1.5 text-xs font-medium leading-snug text-muted-foreground">{metric.title}</h3>
         </div>
         {Icon && (
           <Icon className="h-4 w-4 shrink-0 text-muted-foreground/60" aria-hidden="true" />
@@ -147,18 +147,18 @@ export function MetricsBar({
     <section
       id={id}
       className={cn(
-        isBar ? 'py-0' : compact ? 'py-16 md:py-20' : 'py-16 md:py-24',
+        isBar ? 'px-3 py-0 sm:px-4' : compact ? 'px-3 py-12 sm:px-4 md:py-16' : 'px-3 py-12 sm:px-4 md:py-20',
         className,
       )}
       aria-labelledby={showHeader ? 'metrics-heading' : undefined}
     >
-      <div className="mx-auto max-w-6xl px-6">
+      <div className="mx-auto max-w-6xl">
         {showHeader && (
-          <header className="mb-10 max-w-xl">
+          <header className="mb-8 max-w-xl">
             <h2 id="metrics-heading" className="text-3xl font-semibold tracking-tight md:text-4xl">
               By the numbers
             </h2>
-            <p className="mt-2 text-sm text-muted">
+            <p className="mt-2 text-sm text-muted-foreground">
               Verified metrics · Updated {metricsConfig.lastUpdated}
             </p>
           </header>
@@ -168,7 +168,7 @@ export function MetricsBar({
           ref={ref as React.RefObject<HTMLDivElement>}
           className={cn(
             isBar &&
-              'rounded-xl border border-border/60 bg-accent/40 px-3 py-4 md:rounded-2xl md:px-8 md:py-8',
+              'liquid-glass rounded-[1.25rem] px-3 py-4 sm:rounded-[1.5rem] sm:px-6 sm:py-5 md:px-8 md:py-6',
           )}
         >
           <div

--- a/src/components/sections/MissionSection.tsx
+++ b/src/components/sections/MissionSection.tsx
@@ -1,18 +1,23 @@
-// src/components/sections/MissionSection.tsx — Mission (the WHY) section
+// src/components/sections/MissionSection.tsx — Mission section with glass principles grid
 import { mission } from '@/data/mission'
 import { Section } from '@/components/ui/section'
 
 export function MissionSection() {
   return (
-    <Section id="mission" eyebrow={mission.eyebrow} title={mission.title}>
-      <div className="grid gap-16 lg:grid-cols-2 lg:gap-24">
-        <p className="max-w-md text-base text-muted leading-relaxed">{mission.paragraph}</p>
+    <Section id="mission" eyebrow={mission.eyebrow} title={mission.title} compact glass>
+      <div className="grid gap-8 lg:grid-cols-2 lg:gap-12">
+        <p className="max-w-md text-base leading-relaxed text-muted-foreground">{mission.paragraph}</p>
 
-        <dl className="grid gap-6 sm:grid-cols-2">
+        <dl className="grid gap-3 sm:grid-cols-2">
           {mission.principles.map((principle) => (
-            <div key={principle.title}>
-              <dt className="font-medium">{principle.title}</dt>
-              <dd className="mt-1 text-sm text-muted leading-snug">{principle.description}</dd>
+            <div
+              key={principle.title}
+              className="liquid-glass-card rounded-2xl p-4 sm:p-5"
+            >
+              <dt className="font-semibold tracking-tight">{principle.title}</dt>
+              <dd className="mt-1.5 text-sm leading-snug text-muted-foreground">
+                {principle.description}
+              </dd>
             </div>
           ))}
         </dl>

--- a/src/components/sections/PageHeader.tsx
+++ b/src/components/sections/PageHeader.tsx
@@ -1,5 +1,6 @@
-// src/components/sections/PageHeader.tsx — Reusable page header for subpages
+// src/components/sections/PageHeader.tsx — Subpage header with glass surface
 import { motion } from 'framer-motion'
+import { Eyebrow } from '@/components/ui/eyebrow'
 
 interface PageHeaderProps {
   eyebrow?: string
@@ -10,47 +11,26 @@ interface PageHeaderProps {
 
 export function PageHeader({ eyebrow, title, description, lastUpdated }: PageHeaderProps) {
   return (
-    <header className="border-b border-border py-20 md:py-28">
-      <div className="mx-auto max-w-6xl px-6">
-        {eyebrow && (
-          <motion.p
-            className="mb-4 text-sm font-medium tracking-wide text-muted uppercase"
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.4 }}
-          >
-            {eyebrow}
-          </motion.p>
-        )}
-        <motion.h1
-          className="text-5xl font-semibold tracking-tight text-balance md:text-6xl lg:text-7xl"
-          initial={{ opacity: 0, y: 12 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.05 }}
-        >
+    <header className="px-3 pb-2 pt-2 sm:px-4">
+      <motion.div
+        className="mx-auto max-w-6xl liquid-glass rounded-[1.5rem] p-6 sm:rounded-[1.75rem] sm:p-8 md:p-10"
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
+      >
+        {eyebrow && <Eyebrow className="mb-3">{eyebrow}</Eyebrow>}
+        <h1 className="text-balance text-[2rem] font-semibold leading-[1.08] tracking-tight sm:text-5xl lg:text-6xl">
           {title}
-        </motion.h1>
+        </h1>
         {description && (
-          <motion.p
-            className="mt-6 max-w-lg text-base text-muted leading-relaxed"
-            initial={{ opacity: 0, y: 12 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.1 }}
-          >
+          <p className="mt-4 max-w-lg text-base leading-relaxed text-muted-foreground sm:mt-5 sm:text-lg">
             {description}
-          </motion.p>
+          </p>
         )}
         {lastUpdated && (
-          <motion.p
-            className="mt-4 text-xs text-muted-foreground"
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.5, delay: 0.15 }}
-          >
-            Last updated · {lastUpdated}
-          </motion.p>
+          <p className="mt-4 text-xs text-muted-foreground">Last updated · {lastUpdated}</p>
         )}
-      </div>
+      </motion.div>
     </header>
   )
 }

--- a/src/components/sections/VenturesSection.tsx
+++ b/src/components/sections/VenturesSection.tsx
@@ -1,4 +1,4 @@
-// src/components/sections/VenturesSection.tsx — Companies and ventures
+// src/components/sections/VenturesSection.tsx — Companies and ventures in glass cards
 import { Link } from 'react-router-dom'
 import { ArrowRight, ExternalLink } from 'lucide-react'
 import { ventures } from '@/data/ventures'
@@ -13,21 +13,21 @@ function VentureCard({ venture }: { venture: (typeof ventures)[0] }) {
   return (
     <article
       className={cn(
-        'rounded-xl border border-border/60 p-8 transition-colors hover:border-border',
-        isPrimary && 'border-kch/20 bg-gradient-to-br from-kch-muted/20 to-card',
+        'liquid-glass-card rounded-2xl p-5 transition-transform duration-200 hover:scale-[1.005] sm:p-6',
+        isPrimary && 'ring-1 ring-kch/25',
       )}
     >
       <div className="flex items-start justify-between gap-4">
         <div>
           {isPrimary && (
-            <Badge variant="primary" className="mb-3">
+            <Badge variant="primary" className="mb-2.5">
               Primary
             </Badge>
           )}
-          <h3 className={cn('font-semibold tracking-tight', isPrimary ? 'text-2xl' : 'text-xl')}>
+          <h3 className={cn('font-semibold tracking-tight', isPrimary ? 'text-xl sm:text-2xl' : 'text-lg sm:text-xl')}>
             {venture.name}
           </h3>
-          <p className="mt-1 text-sm text-muted">
+          <p className="mt-1 text-sm text-muted-foreground">
             {venture.role}
             {venture.founded && ` · ${venture.founded}`}
           </p>
@@ -41,14 +41,14 @@ function VentureCard({ venture }: { venture: (typeof ventures)[0] }) {
         </Badge>
       </div>
 
-      <p className="mt-4 max-w-lg text-sm text-muted leading-snug">{venture.description}</p>
+      <p className="mt-4 max-w-lg text-sm leading-snug text-muted-foreground">{venture.description}</p>
 
       {venture.url && (
         <a
           href={venture.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="mt-5 inline-flex items-center gap-1.5 text-sm font-medium transition-opacity hover:opacity-70"
+          className="mt-4 inline-flex items-center gap-1.5 text-sm font-semibold text-[#0071e3] transition-opacity hover:opacity-80"
         >
           Visit
           <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
@@ -76,15 +76,16 @@ export function VenturesSection({
       title="Ventures"
       hideHeader={hideHeader}
       compact={compact}
+      glass
     >
-      <div className="grid gap-4">
+      <div className="grid gap-3">
         {displayed.map((venture) => (
           <VentureCard key={venture.id} venture={venture} />
         ))}
       </div>
 
       {!showAll && ventures.length > 1 && (
-        <div className="mt-12">
+        <div className="mt-8 sm:mt-10">
           <Button asChild variant="secondary">
             <Link to="/ventures">
               All ventures

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,30 +1,34 @@
-// src/components/ui/button.tsx — Reusable button component
+// src/components/ui/button.tsx
+// Apple-inspired pill buttons with glass and solid variants.
+
+import { forwardRef } from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
-import { forwardRef } from 'react'
 import { cn } from '@/lib/utils'
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-semibold transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0071e3]/40 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 active:scale-[0.98]',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:opacity-90 shadow-premium',
+        primary:
+          'bg-[#0071e3] text-white shadow-[0_2px_12px_rgba(0,113,227,0.35)] hover:bg-[#0077ed] hover:shadow-[0_4px_16px_rgba(0,113,227,0.4)]',
         secondary:
-          'bg-accent text-accent-foreground hover:bg-accent/80 border border-border',
-        outline: 'border border-border bg-transparent hover:bg-accent',
-        ghost: 'hover:bg-accent',
-        link: 'text-foreground underline-offset-4 hover:underline',
+          'border border-white/60 bg-white/50 text-foreground shadow-sm backdrop-blur-xl hover:bg-white/70',
+        ghost: 'text-foreground hover:bg-foreground/5',
+        outline:
+          'border border-foreground/10 bg-white/30 text-foreground backdrop-blur-sm hover:bg-white/50',
+        link: 'text-[#0071e3] underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-11 px-6',
-        sm: 'h-9 px-4 text-xs',
+        sm: 'h-9 px-4 text-[13px]',
         lg: 'h-12 px-8 text-base',
         icon: 'h-10 w-10',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'primary',
       size: 'default',
     },
   },
@@ -40,7 +44,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button'
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
     )
   },
 )

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,4 +1,6 @@
-// src/components/ui/card.tsx — Reusable card component
+// src/components/ui/card.tsx
+// Liquid glass card primitives for content surfaces.
+
 import { forwardRef } from 'react'
 import { cn } from '@/lib/utils'
 
@@ -6,7 +8,10 @@ const Card = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn('rounded-2xl border border-border bg-card text-card-foreground shadow-premium', className)}
+      className={cn(
+        'rounded-[1.25rem] border border-white/55 bg-white/45 shadow-[0_4px_24px_rgba(15,23,42,0.05)] backdrop-blur-2xl backdrop-saturate-150',
+        className,
+      )}
       {...props}
     />
   ),
@@ -15,28 +20,33 @@ Card.displayName = 'Card'
 
 const CardHeader = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col gap-1.5 p-6', className)} {...props} />
+    <div ref={ref} className={cn('flex flex-col gap-1.5 p-5 sm:p-6', className)} {...props} />
   ),
 )
 CardHeader.displayName = 'CardHeader'
 
-const CardTitle = forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+const CardTitle = forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn('text-lg font-semibold tracking-tight', className)} {...props} />
+    <h3
+      ref={ref}
+      className={cn('text-lg font-semibold tracking-tight text-foreground sm:text-xl', className)}
+      {...props}
+    />
   ),
 )
 CardTitle.displayName = 'CardTitle'
 
-const CardDescription = forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn('text-sm text-muted leading-relaxed', className)} {...props} />
-  ),
-)
+const CardDescription = forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm leading-relaxed text-muted-foreground', className)} {...props} />
+))
 CardDescription.displayName = 'CardDescription'
 
 const CardContent = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+    <div ref={ref} className={cn('p-5 pt-0 sm:p-6 sm:pt-0', className)} {...props} />
   ),
 )
 CardContent.displayName = 'CardContent'

--- a/src/components/ui/eyebrow.tsx
+++ b/src/components/ui/eyebrow.tsx
@@ -1,4 +1,4 @@
-// src/components/ui/eyebrow.tsx — Consistent editorial eyebrow label
+// src/components/ui/eyebrow.tsx — Apple-style eyebrow label
 import { cn } from '@/lib/utils'
 
 interface EyebrowProps {
@@ -10,7 +10,7 @@ export function Eyebrow({ children, className }: EyebrowProps) {
   return (
     <p
       className={cn(
-        'text-xs font-medium tracking-[0.14em] text-muted uppercase',
+        'text-[11px] font-semibold tracking-[0.12em] text-[#0071e3] uppercase sm:text-xs',
         className,
       )}
     >

--- a/src/components/ui/glass-panel.tsx
+++ b/src/components/ui/glass-panel.tsx
@@ -1,0 +1,30 @@
+// src/components/ui/glass-panel.tsx — Liquid glass surface container
+import { cn } from '@/lib/utils'
+
+interface GlassPanelProps {
+  children: React.ReactNode
+  className?: string
+  variant?: 'panel' | 'card' | 'nav'
+  as?: 'div' | 'section' | 'article'
+}
+
+export function GlassPanel({
+  children,
+  className,
+  variant = 'panel',
+  as: Tag = 'div',
+}: GlassPanelProps) {
+  return (
+    <Tag
+      className={cn(
+        'rounded-3xl',
+        variant === 'panel' && 'liquid-glass',
+        variant === 'card' && 'liquid-glass-card',
+        variant === 'nav' && 'liquid-glass-nav',
+        className,
+      )}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/src/components/ui/section.tsx
+++ b/src/components/ui/section.tsx
@@ -1,4 +1,4 @@
-// src/components/ui/section.tsx — Reusable page section wrapper
+// src/components/ui/section.tsx — Mobile-first section wrapper with optional glass surfaces
 import { motion } from 'framer-motion'
 import { Eyebrow } from '@/components/ui/eyebrow'
 import { useInView } from '@/hooks/useInView'
@@ -16,6 +16,8 @@ interface SectionProps {
   animate?: boolean
   hideHeader?: boolean
   compact?: boolean
+  /** Wrap content in a frosted glass panel for visual flow */
+  glass?: boolean
 }
 
 export function Section({
@@ -29,6 +31,7 @@ export function Section({
   animate = true,
   hideHeader = false,
   compact = false,
+  glass = false,
 }: SectionProps) {
   const { ref, inView } = useInView()
   const reducedMotion = useReducedMotion()
@@ -36,19 +39,31 @@ export function Section({
   const content = (
     <section
       id={id}
-      className={cn(compact ? 'py-20 md:py-28' : 'py-28 md:py-40', className)}
+      className={cn(
+        compact ? 'px-3 py-8 sm:px-4 md:py-14' : 'px-3 py-12 sm:px-4 md:py-20',
+        className,
+      )}
     >
-      <div className={cn('mx-auto max-w-6xl px-6', containerClassName)}>
+      <div
+        className={cn(
+          'mx-auto max-w-6xl',
+          glass &&
+            'liquid-glass rounded-[1.5rem] p-5 sm:rounded-[1.75rem] sm:p-8 lg:p-10',
+          containerClassName,
+        )}
+      >
         {!hideHeader && (eyebrow || title || description) && (
-          <header className={cn('max-w-2xl', compact ? 'mb-12' : 'mb-20')}>
-            {eyebrow && <Eyebrow className="mb-4">{eyebrow}</Eyebrow>}
+          <header className={cn('max-w-2xl', compact ? 'mb-8 sm:mb-10' : 'mb-10 sm:mb-14')}>
+            {eyebrow && <Eyebrow className="mb-3">{eyebrow}</Eyebrow>}
             {title && (
-              <h2 className="text-4xl font-semibold tracking-tight text-balance md:text-5xl lg:text-6xl">
+              <h2 className="text-balance text-[1.75rem] font-semibold leading-[1.12] tracking-tight text-foreground sm:text-4xl lg:text-[2.75rem]">
                 {title}
               </h2>
             )}
             {description && (
-              <p className="mt-5 text-base text-muted leading-relaxed text-balance">{description}</p>
+              <p className="mt-3 text-pretty text-base leading-relaxed text-muted-foreground sm:mt-4 sm:text-lg">
+                {description}
+              </p>
             )}
           </header>
         )}
@@ -62,9 +77,9 @@ export function Section({
   return (
     <motion.div
       ref={ref as React.RefObject<HTMLDivElement>}
-      initial={{ opacity: 0, y: 20 }}
+      initial={{ opacity: 0, y: 16 }}
       animate={inView ? { opacity: 1, y: 0 } : {}}
-      transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.5, ease: [0.25, 0.1, 0.25, 1] }}
     >
       {content}
     </motion.div>

--- a/src/components/visuals/FlagshipPanel.tsx
+++ b/src/components/visuals/FlagshipPanel.tsx
@@ -1,4 +1,4 @@
-// src/components/visuals/FlagshipPanel.tsx — KCH feature pillars and proof snapshot (no duplicate mockup)
+// src/components/visuals/FlagshipPanel.tsx — KCH feature pillars and proof snapshot
 import { Check, ExternalLink } from 'lucide-react'
 import { kidsCallHome } from '@/data/kids-call-home'
 import { getMetric } from '@/data/metrics'
@@ -13,10 +13,10 @@ export function FlagshipPanel({ className }: FlagshipPanelProps) {
   const countries = getMetric('countries')
 
   return (
-    <div className={cn('flex flex-col gap-5 md:gap-8', className)}>
-      <ul className="space-y-2.5 md:space-y-4" aria-label="Product highlights">
+    <div className={cn('flex flex-col gap-5', className)}>
+      <ul className="space-y-2.5" aria-label="Product highlights">
         {kidsCallHome.pillars.map((pillar) => (
-          <li key={pillar} className="flex items-start gap-2.5 md:gap-3">
+          <li key={pillar} className="flex items-start gap-2.5">
             <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-kch-subtle">
               <Check className="h-3 w-3 text-kch" aria-hidden="true" />
             </span>
@@ -25,21 +25,21 @@ export function FlagshipPanel({ className }: FlagshipPanelProps) {
         ))}
       </ul>
 
-      <div className="grid grid-cols-2 gap-2.5 md:gap-3">
+      <div className="grid grid-cols-2 gap-2.5">
         {trustedAdults && (
-          <div className="rounded-xl border border-border/60 bg-card/60 px-3 py-2.5 md:px-4 md:py-3">
-            <p className="text-lg font-semibold tracking-tight tabular-nums md:text-xl">
+          <div className="liquid-glass-card rounded-2xl px-3.5 py-3 sm:px-4 sm:py-3.5">
+            <p className="text-lg font-semibold tracking-tight tabular-nums sm:text-xl">
               {trustedAdults.value}
             </p>
-            <p className="mt-0.5 text-[11px] text-muted md:text-xs">{trustedAdults.title}</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground sm:text-xs">{trustedAdults.title}</p>
           </div>
         )}
         {countries && (
-          <div className="rounded-xl border border-border/60 bg-card/60 px-3 py-2.5 md:px-4 md:py-3">
-            <p className="text-lg font-semibold tracking-tight tabular-nums md:text-xl">
+          <div className="liquid-glass-card rounded-2xl px-3.5 py-3 sm:px-4 sm:py-3.5">
+            <p className="text-lg font-semibold tracking-tight tabular-nums sm:text-xl">
               {countries.value}
             </p>
-            <p className="mt-0.5 text-[11px] text-muted md:text-xs">{countries.title}</p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground sm:text-xs">{countries.title}</p>
           </div>
         )}
       </div>
@@ -49,21 +49,21 @@ export function FlagshipPanel({ className }: FlagshipPanelProps) {
           href={kidsCallHome.appStoreUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 text-sm font-medium transition-colors hover:border-foreground/20 md:px-4 md:py-2"
+          className="liquid-glass-card inline-flex items-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-semibold transition-transform duration-200 hover:scale-[1.02]"
           aria-label="Kids Call Home on the Apple App Store"
         >
           App Store
-          <ExternalLink className="h-3 w-3 text-muted" aria-hidden="true" />
+          <ExternalLink className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
         </a>
         <a
           href={kidsCallHome.playStoreUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card px-3.5 py-1.5 text-sm font-medium transition-colors hover:border-foreground/20 md:px-4 md:py-2"
+          className="liquid-glass-card inline-flex items-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-semibold transition-transform duration-200 hover:scale-[1.02]"
           aria-label="Kids Call Home on Google Play"
         >
           Google Play
-          <ExternalLink className="h-3 w-3 text-muted" aria-hidden="true" />
+          <ExternalLink className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
         </a>
       </div>
     </div>

--- a/src/components/visuals/ProductMockup.tsx
+++ b/src/components/visuals/ProductMockup.tsx
@@ -32,7 +32,7 @@ export function ProductMockup({ compact = false, className }: ProductMockupProps
 
       <motion.div
         className={cn(
-          'absolute rounded-2xl border border-glass-border glass shadow-elevated',
+          'absolute rounded-2xl liquid-glass-card shadow-elevated',
           compact
             ? 'top-1 right-0 w-[72%] p-3 sm:top-2 sm:p-4'
             : 'top-8 right-0 w-[75%] p-5',
@@ -43,7 +43,7 @@ export function ProductMockup({ compact = false, className }: ProductMockupProps
       >
         <div className={cn('flex items-center gap-2', compact ? 'mb-2' : 'mb-4')}>
           <div className="h-2 w-2 rounded-full bg-emerald-400 sm:h-2.5 sm:w-2.5" />
-          <span className={cn('font-medium text-muted', compact ? 'text-[10px]' : 'text-xs')}>
+          <span className={cn('font-medium text-muted-foreground', compact ? 'text-[10px]' : 'text-xs')}>
             Family Dashboard
           </span>
         </div>
@@ -66,7 +66,7 @@ export function ProductMockup({ compact = false, className }: ProductMockupProps
               </div>
               <div className="min-w-0 flex-1">
                 <p className={cn('font-medium', compact ? 'text-[10px]' : 'text-xs')}>{name}</p>
-                <p className={cn('text-muted', compact ? 'text-[9px]' : 'text-[10px]')}>Available</p>
+                <p className={cn('text-muted-foreground', compact ? 'text-[9px]' : 'text-[10px]')}>Available</p>
               </div>
               <div
                 className={cn(
@@ -83,7 +83,7 @@ export function ProductMockup({ compact = false, className }: ProductMockupProps
 
       <motion.div
         className={cn(
-          'absolute bottom-0 left-0 border border-glass-border bg-card shadow-elevated',
+          'absolute bottom-0 left-0 liquid-glass-card shadow-elevated',
           compact
             ? 'w-[58%] rounded-[1.5rem] p-2'
             : 'w-[65%] rounded-[2rem] p-3',
@@ -106,12 +106,12 @@ export function ProductMockup({ compact = false, className }: ProductMockupProps
                 compact ? 'h-3.5 w-12' : 'h-5 w-16',
               )}
             />
-            <Phone className={cn('text-muted', compact ? 'h-2.5 w-2.5' : 'h-3 w-3')} />
+            <Phone className={cn('text-muted-foreground', compact ? 'h-2.5 w-2.5' : 'h-3 w-3')} />
           </div>
 
           <div className={cn(compact ? 'px-3 pb-3 pt-0.5' : 'px-5 pb-6 pt-2')}>
             <p className={cn('font-semibold', compact ? 'text-xs' : 'text-sm')}>Kids Call Home</p>
-            <p className={cn('text-muted', compact ? 'text-[9px]' : 'text-[10px]')}>
+            <p className={cn('text-muted-foreground', compact ? 'text-[9px]' : 'text-[10px]')}>
               Tap to call family
             </p>
 
@@ -171,7 +171,7 @@ export function ProductMockup({ compact = false, className }: ProductMockupProps
 
       <motion.div
         className={cn(
-          'absolute rounded-full border border-glass-border glass shadow-premium',
+          'absolute rounded-full liquid-glass-card shadow-premium',
           compact
             ? 'top-[42%] right-0 px-2 py-0.5'
             : 'top-1/2 right-4 px-4 py-2',

--- a/src/index.css
+++ b/src/index.css
@@ -1,58 +1,66 @@
-/* src/index.css — Global styles and design tokens */
+/* src/index.css — Global styles, liquid glass design system */
 @import 'tailwindcss';
 
 @custom-variant dark (&:where(.dark, .dark *));
 
 @theme {
-  --font-sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'SF Pro Text', 'Inter', system-ui,
+    sans-serif;
 
-  --color-background: #fafaf9;
-  --color-foreground: #1c1917;
-  --color-muted: #78716c;
-  --color-muted-foreground: #a8a29e;
-  --color-border: #e7e5e4;
-  --color-card: #ffffff;
-  --color-card-foreground: #1c1917;
-  --color-accent: #f5f5f4;
-  --color-accent-foreground: #1c1917;
-  --color-primary: #1c1917;
-  --color-primary-foreground: #fafaf9;
-  --color-ring: #d6d3d1;
-  --color-surface: #ffffff;
-  --color-surface-elevated: #ffffff;
-  --color-gradient-start: #fafaf9;
-  --color-gradient-end: #f5f5f4;
-  --color-glass: rgba(255, 255, 255, 0.72);
-  --color-glass-border: rgba(0, 0, 0, 0.06);
-  --color-hero-glow: rgba(120, 113, 108, 0.08);
-  --color-kch: #2563eb;
-  --color-kch-muted: #dbeafe;
-  --color-kch-subtle: rgba(37, 99, 235, 0.08);
+  --color-background: #f5f5f7;
+  --color-foreground: #1d1d1f;
+  --color-muted: #6e6e73;
+  --color-muted-foreground: #86868b;
+  --color-border: rgba(0, 0, 0, 0.08);
+  --color-card: rgba(255, 255, 255, 0.72);
+  --color-card-foreground: #1d1d1f;
+  --color-accent: rgba(0, 0, 0, 0.04);
+  --color-accent-foreground: #1d1d1f;
+  --color-primary: #1d1d1f;
+  --color-primary-foreground: #f5f5f7;
+  --color-ring: rgba(0, 0, 0, 0.12);
+  --color-surface: rgba(255, 255, 255, 0.8);
+  --color-surface-elevated: rgba(255, 255, 255, 0.92);
+  --color-gradient-start: #f5f5f7;
+  --color-gradient-end: #e8e8ed;
+  --color-glass: rgba(255, 255, 255, 0.55);
+  --color-glass-border: rgba(255, 255, 255, 0.65);
+  --color-hero-glow: rgba(0, 122, 255, 0.12);
+  --color-kch: #007aff;
+  --color-kch-muted: rgba(0, 122, 255, 0.14);
+  --color-kch-subtle: rgba(0, 122, 255, 0.1);
+  --color-orb-blue: rgba(0, 122, 255, 0.22);
+  --color-orb-violet: rgba(88, 86, 214, 0.18);
+  --color-orb-teal: rgba(48, 209, 88, 0.12);
 }
 
 .dark {
-  --color-background: #0c0a09;
-  --color-foreground: #fafaf9;
-  --color-muted: #a8a29e;
-  --color-muted-foreground: #78716c;
-  --color-border: #292524;
-  --color-card: #1c1917;
-  --color-card-foreground: #fafaf9;
-  --color-accent: #292524;
-  --color-accent-foreground: #fafaf9;
-  --color-primary: #fafaf9;
-  --color-primary-foreground: #0c0a09;
-  --color-ring: #44403c;
-  --color-surface: #1c1917;
-  --color-surface-elevated: #292524;
-  --color-gradient-start: #0c0a09;
-  --color-gradient-end: #1c1917;
-  --color-glass: rgba(28, 25, 23, 0.72);
-  --color-glass-border: rgba(255, 255, 255, 0.08);
-  --color-hero-glow: rgba(120, 113, 108, 0.12);
-  --color-kch: #3b82f6;
-  --color-kch-muted: #1e3a5f;
-  --color-kch-subtle: rgba(59, 130, 246, 0.12);
+  --color-background: #000000;
+  --color-foreground: #f5f5f7;
+  --color-muted: #a1a1a6;
+  --color-muted-foreground: #6e6e73;
+  --color-border: rgba(255, 255, 255, 0.1);
+  --color-card: rgba(28, 28, 30, 0.72);
+  --color-card-foreground: #f5f5f7;
+  --color-accent: rgba(255, 255, 255, 0.06);
+  --color-accent-foreground: #f5f5f7;
+  --color-primary: #f5f5f7;
+  --color-primary-foreground: #000000;
+  --color-ring: rgba(255, 255, 255, 0.15);
+  --color-surface: rgba(28, 28, 30, 0.8);
+  --color-surface-elevated: rgba(44, 44, 46, 0.88);
+  --color-gradient-start: #000000;
+  --color-gradient-end: #0d0d0f;
+  --color-glass: rgba(28, 28, 30, 0.55);
+  --color-glass-border: rgba(255, 255, 255, 0.12);
+  --color-hero-glow: rgba(10, 132, 255, 0.15);
+  --color-kch: #0a84ff;
+  --color-kch-muted: rgba(10, 132, 255, 0.2);
+  --color-kch-subtle: rgba(10, 132, 255, 0.14);
+  --color-orb-blue: rgba(10, 132, 255, 0.28);
+  --color-orb-violet: rgba(94, 92, 230, 0.22);
+  --color-orb-teal: rgba(48, 209, 88, 0.14);
 }
 
 @layer base {
@@ -64,15 +72,17 @@
     scroll-behavior: smooth;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
   }
 
   body {
     @apply bg-background text-foreground font-sans;
     font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
+    letter-spacing: -0.01em;
   }
 
   ::selection {
-    @apply bg-foreground/10;
+    @apply bg-kch/20 text-foreground;
   }
 }
 
@@ -81,52 +91,164 @@
     text-wrap: balance;
   }
 
-  .bg-dot-grid {
-    background-image: radial-gradient(circle, var(--color-border) 1px, transparent 1px);
-    background-size: 24px 24px;
+  .ambient-bg {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    background: var(--color-background);
+    pointer-events: none;
+  }
+
+  .ambient-orb {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    will-change: transform;
+  }
+
+  .ambient-orb-blue {
+    background: var(--color-orb-blue);
+  }
+
+  .ambient-orb-violet {
+    background: var(--color-orb-violet);
+  }
+
+  .ambient-orb-teal {
+    background: var(--color-orb-teal);
+  }
+
+  .liquid-glass {
+    background: linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.72) 0%,
+      rgba(255, 255, 255, 0.38) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(40px) saturate(180%);
+    -webkit-backdrop-filter: blur(40px) saturate(180%);
+    box-shadow:
+      0 4px 24px rgba(0, 0, 0, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  }
+
+  .dark .liquid-glass {
+    background: linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.1) 0%,
+      rgba(255, 255, 255, 0.03) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+
+  .liquid-glass-card {
+    background: linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.65) 0%,
+      rgba(255, 255, 255, 0.32) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(32px) saturate(160%);
+    -webkit-backdrop-filter: blur(32px) saturate(160%);
+    box-shadow:
+      0 2px 16px rgba(0, 0, 0, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.55);
+  }
+
+  .dark .liquid-glass-card {
+    background: linear-gradient(
+      160deg,
+      rgba(255, 255, 255, 0.09) 0%,
+      rgba(255, 255, 255, 0.02) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow:
+      0 4px 20px rgba(0, 0, 0, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+
+  .liquid-glass-nav {
+    background: rgba(255, 255, 255, 0.62);
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(48px) saturate(200%);
+    -webkit-backdrop-filter: blur(48px) saturate(200%);
+    box-shadow:
+      0 4px 30px rgba(0, 0, 0, 0.06),
+      inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  }
+
+  .dark .liquid-glass-nav {
+    background: rgba(28, 28, 30, 0.62);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.5),
+      inset 0 1px 0 rgba(255, 255, 255, 0.08);
   }
 
   .glass {
-    background: var(--color-glass);
-    border: 1px solid var(--color-glass-border);
-    backdrop-filter: blur(20px);
-    -webkit-backdrop-filter: blur(20px);
+    background: linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.72) 0%,
+      rgba(255, 255, 255, 0.38) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(40px) saturate(180%);
+    -webkit-backdrop-filter: blur(40px) saturate(180%);
+    box-shadow:
+      0 4px 24px rgba(0, 0, 0, 0.04),
+      inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  }
+
+  .dark .glass {
+    background: linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.1) 0%,
+      rgba(255, 255, 255, 0.03) 100%
+    );
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow:
+      0 8px 32px rgba(0, 0, 0, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
   }
 
   .gradient-subtle {
-    background: linear-gradient(
-      180deg,
-      var(--color-gradient-start) 0%,
-      var(--color-gradient-end) 100%
-    );
+    background: transparent;
   }
 
   .shadow-premium {
     box-shadow:
-      0 0 0 1px var(--color-glass-border),
-      0 2px 4px rgba(0, 0, 0, 0.02),
-      0 12px 24px rgba(0, 0, 0, 0.04);
+      0 0 0 1px rgba(255, 255, 255, 0.4),
+      0 4px 20px rgba(0, 0, 0, 0.05);
   }
 
   .dark .shadow-premium {
     box-shadow:
-      0 0 0 1px var(--color-glass-border),
-      0 2px 4px rgba(0, 0, 0, 0.2),
-      0 12px 24px rgba(0, 0, 0, 0.3);
+      0 0 0 1px rgba(255, 255, 255, 0.08),
+      0 4px 20px rgba(0, 0, 0, 0.35);
   }
 
   .shadow-elevated {
     box-shadow:
-      0 0 0 1px var(--color-glass-border),
-      0 4px 8px rgba(0, 0, 0, 0.03),
-      0 24px 48px rgba(0, 0, 0, 0.06);
+      0 0 0 1px rgba(255, 255, 255, 0.35),
+      0 12px 40px rgba(0, 0, 0, 0.08);
   }
 
   .dark .shadow-elevated {
     box-shadow:
-      0 0 0 1px var(--color-glass-border),
-      0 4px 8px rgba(0, 0, 0, 0.3),
-      0 24px 48px rgba(0, 0, 0, 0.4);
+      0 0 0 1px rgba(255, 255, 255, 0.08),
+      0 12px 40px rgba(0, 0, 0, 0.45);
+  }
+
+  .section-flow {
+    @apply py-14 md:py-24;
+  }
+
+  .section-flow-compact {
+    @apply py-10 md:py-20;
   }
 }
 

--- a/src/pages/EvidencePage.tsx
+++ b/src/pages/EvidencePage.tsx
@@ -22,7 +22,7 @@ export function EvidencePage() {
         description="Verifiable facts from distribution, platforms, and public presence."
         lastUpdated={evidenceConfig.lastUpdated}
       />
-      <EvidenceSection hideHeader showProductMetrics />
+      <EvidenceSection hideHeader showProductMetrics glass={false} />
     </>
   )
 }

--- a/src/pages/KidsCallHomePage.tsx
+++ b/src/pages/KidsCallHomePage.tsx
@@ -1,4 +1,4 @@
-// src/pages/KidsCallHomePage.tsx — Dedicated Kids Call Home page
+// src/pages/KidsCallHomePage.tsx — Dedicated Kids Call Home page with glass surfaces
 import { ExternalLink } from 'lucide-react'
 import { kidsCallHome } from '@/data/kids-call-home'
 import { getMetric, metricsConfig } from '@/data/metrics'
@@ -29,19 +29,19 @@ export function KidsCallHomePage() {
       <PageMetaTags meta={pageMeta.kidsCallHome} />
       <JsonLd data={breadcrumbs} />
 
-      <header className="border-b border-border">
-        <div className="mx-auto max-w-6xl px-6 py-10 md:py-14">
-          <div className="grid items-center gap-8 lg:grid-cols-2 lg:gap-12">
+      <header className="px-3 pt-2 sm:px-4">
+        <div className="mx-auto max-w-6xl liquid-glass rounded-[1.5rem] p-6 sm:rounded-[1.75rem] sm:p-8">
+          <div className="grid items-center gap-6 lg:grid-cols-2 lg:gap-10">
             <div>
-              <Eyebrow className="mb-3">Flagship</Eyebrow>
-              <h1 className="text-4xl font-semibold tracking-tight text-balance md:text-5xl lg:text-6xl">
+              <Eyebrow className="mb-2.5">Flagship</Eyebrow>
+              <h1 className="text-balance text-[2rem] font-semibold leading-[1.08] tracking-tight sm:text-4xl lg:text-5xl">
                 {kidsCallHome.name}
               </h1>
-              <p className="mt-4 max-w-md text-base text-muted leading-relaxed">
+              <p className="mt-3 max-w-md text-base leading-relaxed text-muted-foreground sm:mt-4">
                 {kidsCallHome.summary}
               </p>
             </div>
-            <ProductMockup compact className="lg:justify-self-end" />
+            <ProductMockup compact className="mx-auto lg:justify-self-end" />
           </div>
         </div>
       </header>
@@ -51,21 +51,21 @@ export function KidsCallHomePage() {
         showHeader={false}
         variant="bar"
         metrics={kchMetrics}
-        className="py-6 md:py-8"
+        className="px-3 py-4 sm:px-4 md:py-6"
       />
 
-      <Section eyebrow="Features" title="Built for families." className="gradient-subtle py-16 md:py-24" animate={false}>
-        <dl className="grid gap-6 sm:grid-cols-3 md:gap-8">
+      <Section eyebrow="Features" title="Built for families." compact glass animate={false}>
+        <dl className="grid gap-3 sm:grid-cols-3">
           {kidsCallHome.features.map((f) => (
-            <div key={f.title}>
-              <dt className="font-medium">{f.title}</dt>
-              <dd className="mt-1 text-sm text-muted leading-snug">{f.description}</dd>
+            <div key={f.title} className="liquid-glass-card rounded-2xl p-4 sm:p-5">
+              <dt className="font-semibold tracking-tight">{f.title}</dt>
+              <dd className="mt-1.5 text-sm leading-snug text-muted-foreground">{f.description}</dd>
             </div>
           ))}
         </dl>
       </Section>
 
-      <Section eyebrow="Platforms" title="Available everywhere." className="py-16 md:py-24" animate={false}>
+      <Section eyebrow="Platforms" title="Available everywhere." compact glass animate={false}>
         <div className="flex flex-wrap gap-3">
           {kidsCallHome.platforms.map((p) => (
             <a
@@ -73,7 +73,7 @@ export function KidsCallHomePage() {
               href={p.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex min-w-[120px] flex-col items-center rounded-xl border border-border/60 px-6 py-5 transition-colors hover:border-border md:px-8 md:py-6"
+              className="liquid-glass-card flex min-w-[120px] flex-col items-center rounded-2xl px-6 py-5 transition-transform duration-200 hover:scale-[1.02] md:px-8 md:py-6"
             >
               <p className="text-lg font-semibold">{p.name}</p>
               <Badge variant="verified" className="mt-2">
@@ -82,9 +82,9 @@ export function KidsCallHomePage() {
             </a>
           ))}
         </div>
-        <div className="mt-8 flex flex-wrap gap-3 md:mt-10">
+        <div className="mt-6 flex flex-col gap-2.5 sm:mt-8 sm:flex-row sm:flex-wrap">
           {kidsCallHome.links.map((link) => (
-            <Button key={link.label} asChild variant={link.primary ? 'default' : 'secondary'}>
+            <Button key={link.label} asChild variant={link.primary ? 'primary' : 'secondary'} className="w-full sm:w-auto">
               <a href={link.url} target="_blank" rel="noopener noreferrer">
                 {link.label}
                 <ExternalLink className="h-4 w-4" aria-hidden="true" />
@@ -94,21 +94,21 @@ export function KidsCallHomePage() {
         </div>
       </Section>
 
-      <Section eyebrow="Timeline" title="Milestones." className="pb-20 md:pb-28" animate={false}>
-        <div className="max-w-xl space-y-5">
+      <Section eyebrow="Timeline" title="Milestones." compact glass animate={false}>
+        <div className="max-w-xl space-y-3">
           {kidsCallHome.timeline.map((event) => (
-            <div key={event.title} className="flex gap-6 md:gap-8">
-              <time className="w-12 shrink-0 text-sm font-medium text-muted tabular-nums md:w-14">
+            <div key={event.title} className="liquid-glass-card flex gap-4 rounded-2xl p-4 sm:gap-5 sm:p-5">
+              <time className="w-12 shrink-0 text-sm font-medium tabular-nums text-muted-foreground sm:w-14">
                 {event.date}
               </time>
               <div>
-                <h3 className="font-medium">{event.title}</h3>
-                <p className="mt-0.5 text-sm text-muted leading-snug">{event.description}</p>
+                <h3 className="font-semibold tracking-tight">{event.title}</h3>
+                <p className="mt-0.5 text-sm leading-snug text-muted-foreground">{event.description}</p>
               </div>
             </div>
           ))}
         </div>
-        <p className="mt-6 text-xs text-muted-foreground">
+        <p className="mt-5 text-xs text-muted-foreground">
           Metrics updated {metricsConfig.lastUpdated}
         </p>
       </Section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Redesigns the site with an Apple-inspired **liquid glass** aesthetic, optimized for mobile-first scrolling flow.

### Design system
- Frosted glass surfaces (`liquid-glass`, `liquid-glass-card`) with backdrop blur and subtle inner highlights
- Ambient mesh gradient orbs behind all pages
- SF Pro / system font stack, Apple blue accent (`#0071e3`), pill buttons
- Tighter mobile spacing with consistent `px-3` gutters and rounded glass panels

### Components updated
- **Header** — floating glass nav bar with animated mobile sheet
- **Hero** — glass content panel; mockup remains desktop-only
- **Homepage sections** — stacked glass panels for KCH, Mission, Evidence, Journey, Ventures, Contact
- **Footer** — glass container with grouped navigation
- **Subpages** — glass page headers; KCH page fully restyled
- **Evidence page** — layout preserved; cards updated to glass styling only

### Mobile flow
- Full-width CTAs on small screens
- KCH section: compact mockup → title → buttons → flagship panel (single column)
- No duplicate mockups or empty aspect-ratio gaps

## Test plan
- [x] `npm run build` passes
- [ ] Verify mobile homepage scroll flow (hero → KCH → mission → evidence → journey → ventures → contact)
- [ ] Confirm Evidence page grid layout unchanged
- [ ] Check glass nav + mobile menu on iOS Safari / Chrome mobile

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2630bf95-57c2-400d-8e5c-f186b612bce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2630bf95-57c2-400d-8e5c-f186b612bce7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

